### PR TITLE
Use JSON output from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,44 @@ steps:
 
 ## Inputs
 
-| Input | Required | Default | Description |
-| --- | --- | --- | --- |
-| `access_key` | Yes | | Linear pipeline access key for authentication |
-| `command` | No | `sync` | Command to run: `sync`, `complete`, or `update` |
-| `name` | No | | Custom release name (only used with `sync` command) |
-| `version` | No | | Release version identifier |
-| `stage` | No | | Deployment stage such as `staging` or `production` (required for `update`) |
-| `include_paths` | No | | Filter commits by file paths (comma-separated globs for monorepos) |
-| `cli_version` | No | `latest` | Linear Release CLI version tag to install |
+| Input           | Required | Default  | Description                                                                |
+| --------------- | -------- | -------- | -------------------------------------------------------------------------- |
+| `access_key`    | Yes      |          | Linear pipeline access key for authentication                              |
+| `command`       | No       | `sync`   | Command to run: `sync`, `complete`, or `update`                            |
+| `name`          | No       |          | Custom release name (only used with `sync` command)                        |
+| `version`       | No       |          | Release version identifier                                                 |
+| `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`) |
+| `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)         |
+| `cli_version`   | No       | `latest` | Linear Release CLI version tag to install                                  |
+
+## Outputs
+
+| Output            | Description                  |
+| ----------------- | ---------------------------- |
+| `release-id`      | The Linear release ID        |
+| `release-name`    | The Linear release name      |
+| `release-version` | The Linear release version   |
+| `release-url`     | URL to the Linear release    |
+
+Outputs are empty when no release is created (e.g. no matching commits found).
+
+### Using outputs
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+
+  - uses: linear/linear-release-action@v0.1.0
+    id: release
+    with:
+      access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+
+  - name: Use release outputs
+    if: steps.release.outputs.release-url
+    run: echo "Release URL is ${{ steps.release.outputs.release-url }}"
+```
 
 ## Commands
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,20 @@ inputs:
     required: false
     default: latest
 
+outputs:
+  release-id:
+    description: The Linear release ID
+    value: ${{ steps.run.outputs.release-id }}
+  release-name:
+    description: The Linear release name
+    value: ${{ steps.run.outputs.release-name }}
+  release-version:
+    description: The Linear release version
+    value: ${{ steps.run.outputs.release-version }}
+  release-url:
+    description: URL to the Linear release
+    value: ${{ steps.run.outputs.release-url }}
+
 runs:
   using: composite
   steps:
@@ -41,6 +55,7 @@ runs:
         CLI_VERSION: ${{ inputs.cli_version }}
 
     - name: Run Linear Release
+      id: run
       shell: bash
       run: bash "${{ github.action_path }}/run.sh"
       env:

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,16 @@ if [[ ! -x "$BIN_PATH" ]]; then
   exit 1
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "::error::jq is required but not found. Install jq or use a GitHub-hosted runner."
+  exit 1
+fi
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "::error::GITHUB_OUTPUT is not set. This action must run inside GitHub Actions."
+  exit 1
+fi
+
 COMMAND="${COMMAND:-sync}"
 case "$COMMAND" in
   sync|complete|update)
@@ -35,5 +45,31 @@ args=()
 [[ -n "${INPUT_STAGE:-}" ]] && args+=("--stage=${INPUT_STAGE}")
 [[ -n "${INPUT_INCLUDE_PATHS:-}" ]] && args+=("--include-paths=${INPUT_INCLUDE_PATHS}")
 
-echo "Running: $BIN_PATH $COMMAND ${args[*]:-}"
-"$BIN_PATH" "$COMMAND" ${args[@]+"${args[@]}"}
+echo "Running: $BIN_PATH $COMMAND ${args[*]}"
+
+output=$("$BIN_PATH" "$COMMAND" --json "${args[@]}")
+
+# Print the raw JSON so it appears in workflow logs
+echo "$output"
+
+# Validate output is valid JSON before parsing
+if ! jq -e . >/dev/null 2>&1 <<<"$output"; then
+  echo "::error::Linear Release CLI did not return valid JSON"
+  exit 1
+fi
+
+# Parse and write outputs
+{
+  echo "release-id<<EOF"
+  jq -r '.release.id // empty' <<<"$output"
+  echo "EOF"
+  echo "release-name<<EOF"
+  jq -r '.release.name // empty' <<<"$output"
+  echo "EOF"
+  echo "release-version<<EOF"
+  jq -r '.release.version // empty' <<<"$output"
+  echo "EOF"
+  echo "release-url<<EOF"
+  jq -r '.release.url // empty' <<<"$output"
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION

  - Add `release-id`, `release-name`, `release-version`, `release-url` action outputs
  - Pass `--json` to CLI and parse response with `jq`
  - Add preflight validation (jq, GITHUB_OUTPUT, valid command)
