### PR TITLE
Add post-action cleanup step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,3 +73,8 @@ runs:
         INPUT_STAGE: ${{ inputs.stage }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include_paths }}
         INPUT_LOG_LEVEL: ${{ inputs.log_level }}
+
+    - name: Cleanup CLI binary
+      if: always()
+      shell: bash
+      run: rm -f "${{ github.action_path }}/linear-release"


### PR DESCRIPTION
Adds a cleanup step (with `if: always()`) at the end of the composite action to remove the downloaded `linear-release` binary after execution.