### PR TITLE
Add support for timeout input

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ steps:
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`) |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)         |
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.              |
-| `timeout`       | No       |          | Maximum time to wait for the command to complete (e.g., `30s`, `5m`)       |
+| `timeout`       | No       |          | Maximum time in seconds to wait for the command to complete (e.g., `30`)   |
 | `cli_version`   | No       | `latest` | Linear Release CLI version tag to install                                  |
 
 `cli_version` defaults to `latest`, so the action automatically uses the newest CLI release. For reproducible builds, pin an exact tag (for example, `v0.5.0`). If stability is more important than automatic updates, prefer a pinned version.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ steps:
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`) |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)         |
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.              |
-| `timeout`       | No       |          | Maximum time in seconds to wait for the command to complete (e.g., `30`)   |
+| `timeout`       | No       | `60`     | Maximum time in seconds to wait for the command to complete                 |
 | `cli_version`   | No       | `latest` | Linear Release CLI version tag to install                                  |
 
 `cli_version` defaults to `latest`, so the action automatically uses the newest CLI release. For reproducible builds, pin an exact tag (for example, `v0.5.0`). If stability is more important than automatic updates, prefer a pinned version.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ steps:
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`) |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)         |
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.              |
+| `timeout`       | No       |          | Maximum time to wait for the command to complete (e.g., `30s`, `5m`)       |
 | `cli_version`   | No       | `latest` | Linear Release CLI version tag to install                                  |
 
 `cli_version` defaults to `latest`, so the action automatically uses the newest CLI release. For reproducible builds, pin an exact tag (for example, `v0.5.0`). If stability is more important than automatic updates, prefer a pinned version.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ steps:
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`) |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)         |
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.              |
-| `timeout`       | No       | `60`     | Maximum time in seconds to wait for the command to complete                 |
+| `timeout`       | No       | `60`     | Maximum time in seconds to wait for the command to complete                |
 | `cli_version`   | No       | `latest` | Linear Release CLI version tag to install                                  |
 
 `cli_version` defaults to `latest`, so the action automatically uses the newest CLI release. For reproducible builds, pin an exact tag (for example, `v0.5.0`). If stability is more important than automatic updates, prefer a pinned version.

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Log verbosity. Use "quiet" for errors only or "verbose" for detailed progress. Omit for default output.
     required: false
   timeout:
-    description: Maximum time to wait for the command to complete (e.g., "30s", "5m"). Passed directly to CLI --timeout flag.
+    description: Maximum time in seconds to wait for the command to complete (e.g., "30"). Passed directly to CLI --timeout flag.
     required: false
   cli_version:
     description: Linear Release CLI version to install (e.g., "v0.5.0" or "latest").

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Log verbosity. Use "quiet" for errors only or "verbose" for detailed progress. Omit for default output.
     required: false
   timeout:
-    description: Maximum time in seconds to wait for the command to complete (e.g., "30"). Passed directly to CLI --timeout flag.
+    description: Maximum time in seconds to wait for the command to complete. Defaults to 60.
     required: false
   cli_version:
     description: Linear Release CLI version to install (e.g., "v0.5.0" or "latest").

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   log_level:
     description: Log verbosity. Use "quiet" for errors only or "verbose" for detailed progress. Omit for default output.
     required: false
+  timeout:
+    description: Maximum time to wait for the command to complete (e.g., "30s", "5m"). Passed directly to CLI --timeout flag.
+    required: false
   cli_version:
     description: Linear Release CLI version to install (e.g., "v0.5.0" or "latest").
     required: false
@@ -73,6 +76,7 @@ runs:
         INPUT_STAGE: ${{ inputs.stage }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include_paths }}
         INPUT_LOG_LEVEL: ${{ inputs.log_level }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
 
     - name: Cleanup CLI binary
       if: always()

--- a/run.sh
+++ b/run.sh
@@ -53,6 +53,7 @@ args=()
 [[ -n "${INPUT_VERSION:-}" ]] && args+=("--release-version=${INPUT_VERSION}")
 [[ -n "${INPUT_STAGE:-}" ]] && args+=("--stage=${INPUT_STAGE}")
 [[ -n "${INPUT_INCLUDE_PATHS:-}" ]] && args+=("--include-paths=${INPUT_INCLUDE_PATHS}")
+[[ -n "${INPUT_TIMEOUT:-}" ]] && args+=("--timeout=${INPUT_TIMEOUT}")
 
 if [[ -n "${INPUT_LOG_LEVEL:-}" ]]; then
   case "$INPUT_LOG_LEVEL" in


### PR DESCRIPTION
Adds a `timeout` input that passes the `--timeout` flag through to the Linear Release CLI, allowing users to configure how long the action waits for a command to complete (e.g., `30s`, `5m`). Updates `action.yml`, `run.sh`, and the README inputs table.