### PR TITLE
Bump default CLI version to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once installed, run it from your AI agent with `/linear-release-setup` (or just 
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)                                                                                                                                                            |
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.                                                                                                                                                                 |
 | `timeout`       | No       | `60`     | Maximum time in seconds to wait for the command to complete                                                                                                                                                                   |
-| `cli_version`   | No       | `v0.7.1` | Linear Release CLI version to install                                                                                                                                                                                         |
+| `cli_version`   | No       | `v0.8.0` | Linear Release CLI version to install                                                                                                                                                                                         |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,9 @@ inputs:
     description: Maximum time in seconds to wait for the command to complete. Defaults to 60.
     required: false
   cli_version:
-    description: Linear Release CLI version to install (e.g., "v0.7.1"). Set to "latest" to always use the newest CLI.
+    description: Linear Release CLI version to install (e.g., "v0.8.0"). Set to "latest" to always use the newest CLI.
     required: false
-    default: v0.7.1
+    default: v0.8.0
 
 outputs:
   release-id:


### PR DESCRIPTION
Picks up [linear-release v0.8.0](https://github.com/linear/linear-release/releases/tag/v0.8.0) which adds `--name` support to the `complete` and `update` commands.