### PR TITLE
Add Linux aarch64 support to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Each release of this action defaults to a specific [Linear Release CLI](https://
 
 **"Unsupported OS" or "Unsupported arch" error**
 
-The action only supports Linux x86_64 and macOS x86_64/arm64 runners. Windows is not supported.
+The action supports Linux (x86_64, aarch64) and macOS (x86_64, arm64) runners. Windows is not supported.
 
 **"access_key input is required" error**
 

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,14 @@ BIN_PATH="${ACTION_PATH}/linear-release"
 case "${RUNNER_OS:-}" in
   Linux)
     ARCH="$(uname -m)"
-    if [[ "$ARCH" != "x86_64" && "$ARCH" != "amd64" ]]; then
-      echo "::error::Unsupported Linux arch: $ARCH. Only x86_64 is supported."
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "amd64" ]]; then
+      ASSET="linear-release-linux-x64"
+    elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+      ASSET="linear-release-linux-arm64"
+    else
+      echo "::error::Unsupported Linux arch: $ARCH. Supported: x86_64, aarch64."
       exit 1
     fi
-    ASSET="linear-release-linux-x64"
     ;;
   macOS)
     ARCH="$(uname -m)"


### PR DESCRIPTION
## Problem

The Linear Release CLI ships a `linear-release-linux-arm64` asset as of [v0.9.0](https://github.com/linear/linear-release/releases/tag/v0.9.0) (PR linear/linear-release#41), but this action's `install.sh` still hard-rejects Linux aarch64:

```
::error::Unsupported Linux arch: aarch64. Only x86_64 is supported.
```

This breaks the action on every ARM64 Linux runner — RunsOn `pool=*-arm`, GitHub-hosted `ubuntu-*-arm`, self-hosted Graviton, etc.

## Fix

Map `aarch64` / `arm64` `uname -m` output to the new `linear-release-linux-arm64` asset, mirroring the existing macOS arch-detection branch.

## Test plan

- [x] `install.sh` syntax check (`bash -n install.sh`)
- [x] Verified the asset URL exists: `https://github.com/linear/linear-release/releases/download/v0.9.0/linear-release-linux-arm64`
- [x] CI on a Linux arm64 runner downloads the correct asset


```
Downloading https://github.com/linear/linear-release/releases/download/v0.9.0/linear-release-linux-arm64
Run set -euo pipefail
Running: linear-release sync --release-version=a02dfb1dbb7deccd156185fd70bbc9474b43af05
=> Using custom release version: a02dfb1dbb7deccd156185fd70bbc9474b43af05
=> Found 1 commit between a02dfb1dbb7deccd156185fd70bbc9474b43af05 and a02dfb1dbb7deccd156185fd70bbc9474b43af05
=> No issue keys found
=> Issues [] and pull requests [161] have been added to release New release
=> Finished
```
