### PR TITLE
Fix release.sh silently failing on rolling tag conflicts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,7 +42,8 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
 fi
 
 # Up to date with origin/main
-git fetch origin main --tags --quiet
+# --force keeps rolling tags (e.g. v0) in sync with the remote so they don't block the fetch.
+git fetch origin main --tags --force
 LOCAL_SHA=$(git rev-parse main)
 REMOTE_SHA=$(git rev-parse origin/main)
 if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then


### PR DESCRIPTION
## Summary
- `scripts/release.sh` preflight ran `git fetch origin main --tags --quiet`, which rejects updates to rolling tags (e.g. `v0`) by default and was silently aborting the whole script under `set -e`.
- Symptom: running `./scripts/release.sh <version>` exits with no output and no PR is created.
- Fix: drop `--quiet` and add `--force` so rolling tags stay in sync and any real fetch errors are surfaced.