### PR TITLE
Onboard to Linear release management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,13 @@ jobs:
         env:
           CLI_VERSION: latest
           RUNNER_OS: ${{ runner.os }}
+
+  sync-release:
+    name: Sync release management
+    needs: [lint, test-install]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/run-linear-release.yml
+    with:
+      action: sync
+    secrets:
+      LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
     name: Sync release management
     needs: [lint, test-install]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
     uses: ./.github/workflows/run-linear-release.yml
     with:
       action: sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
+      version: ${{ steps.vars.outputs.version }}
     steps:
       - name: Checkout tag
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -35,6 +38,7 @@ jobs:
 
           MAJOR="${VERSION%%.*}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major=v$MAJOR" >> "$GITHUB_OUTPUT"
 
       - name: Move floating major tag forward
@@ -59,3 +63,29 @@ jobs:
           gh release create "${TAG}" \
             --title "${TAG}" \
             --generate-notes
+
+  label-release:
+    name: Label release with version
+    needs: release
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run-linear-release.yml
+    with:
+      action: sync
+      name: Release ${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.tag }}
+    secrets:
+      LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}
+
+  complete-release:
+    name: Complete release
+    needs: [release, label-release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run-linear-release.yml
+    with:
+      action: complete
+      name: Release ${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.tag }}
+    secrets:
+      LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}

--- a/.github/workflows/run-linear-release.yml
+++ b/.github/workflows/run-linear-release.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Sync issues
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@v0 # zizmor: ignore[unpinned-uses] dogfooding this repo
         with:
           access_key: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}
           command: sync
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
 
       - name: Complete release
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@v0 # zizmor: ignore[unpinned-uses] dogfooding this repo
         with:
           access_key: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}
           command: complete

--- a/.github/workflows/run-linear-release.yml
+++ b/.github/workflows/run-linear-release.yml
@@ -1,0 +1,78 @@
+name: Run Linear Release
+
+on:
+  workflow_call:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        type: string
+      name:
+        description: "Release name"
+        required: false
+        type: string
+      version:
+        description: "Release version"
+        required: false
+        type: string
+    secrets:
+      LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY:
+        required: true
+
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action"
+        required: true
+        type: choice
+        options:
+          - sync
+          - complete
+      name:
+        description: "Release name"
+        required: false
+        type: string
+      version:
+        description: "Release version"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync issues to release
+    if: inputs.action == 'sync'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Sync issues
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}
+          command: sync
+          name: ${{ inputs.name }}
+          version: ${{ inputs.version }}
+
+  complete:
+    name: Complete release
+    if: inputs.action == 'complete'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Complete release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_MANAGEMENT_ACCESS_KEY }}
+          command: complete
+          name: ${{ inputs.name }}
+          version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Add reusable `run-linear-release.yml` workflow with `sync` and `complete` jobs
- Sync the currently open release on every `main` push via `ci.yml`
- Label release with version (sync) and complete it from `release.yml` after the GitHub Release is created

Mirrors the workflow structure used by [`linear/linear-release`](https://github.com/linear/linear-release/tree/main/.github/workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)