### PR TITLE
Pass include-subjects to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Once installed, run it from your AI agent with `/linear-release-setup` (or just 
 | `version`       | No       |          | Release version identifier (alias: `release_version`)                                                                                                                                                                         |
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`)                                                                                                                                                    |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)                                                                                                                                                            |
+| `include_subjects` | No    |          | Filter commits whose subject (first line) matches a regex (e.g., `[A-Z]{2,}-[0-9]+`)                                                                                                                                          |
 | `base_ref`      | No       |          | Override the `sync` scan base. Exclusive: scans `<base_ref>..HEAD`                                                                                                                                                            |
 | `links`         | No       |          | Links to attach to the targeted release, one per line. Each value must be either an absolute URL or `Label=URL`.                                                                                                              |
 | `documents`     | No       |          | Documents to attach to the targeted release, one per line as `[Title=]path/to/file.md` (title inferred from the filename if omitted). Existing documents with the same title are updated.                                       |
@@ -153,6 +154,17 @@ Filter commits by file paths to track releases for specific packages, useful for
   with:
     access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
     include_paths: apps/web/**,packages/shared/**
+```
+
+### Subject filtering
+
+Filter commits whose subject (first line) matches a regex — useful for dropping noise like bot commits or direct pushes without an issue reference. The regex is matched against the inner subject of revert commits, so revert tracking still works.
+
+```yaml
+- uses: linear/linear-release-action@v0
+  with:
+    access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+    include_subjects: "[A-Z]{2,}-[0-9]+"
 ```
 
 ### Scan base override

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   include_paths:
     description: Filter commits by file paths using comma-separated globs (e.g., "apps/web/**,packages/**"). Useful for monorepos.
     required: false
+  include_subjects:
+    description: Filter commits whose subject (first line) matches a regex (e.g., "[A-Z]{2,}-[0-9]+").
+    required: false
   base_ref:
     description: "Override the sync scan base. Exclusive: scans <base_ref>..HEAD."
     required: false
@@ -87,6 +90,7 @@ runs:
         INPUT_RELEASE_VERSION: ${{ inputs.release_version }}
         INPUT_STAGE: ${{ inputs.stage }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include_paths }}
+        INPUT_INCLUDE_SUBJECTS: ${{ inputs.include_subjects }}
         INPUT_BASE_REF: ${{ inputs.base_ref }}
         INPUT_LINKS: ${{ inputs.links }}
         INPUT_DOCUMENTS: ${{ inputs.documents }}

--- a/run.sh
+++ b/run.sh
@@ -49,6 +49,7 @@ args=()
 [[ -n "${INPUT_VERSION:-}" ]] && args+=("--release-version=${INPUT_VERSION}")
 [[ -n "${INPUT_STAGE:-}" ]] && args+=("--stage=${INPUT_STAGE}")
 [[ -n "${INPUT_INCLUDE_PATHS:-}" ]] && args+=("--include-paths=${INPUT_INCLUDE_PATHS}")
+[[ -n "${INPUT_INCLUDE_SUBJECTS:-}" ]] && args+=("--include-subjects=${INPUT_INCLUDE_SUBJECTS}")
 [[ -n "${INPUT_BASE_REF:-}" ]] && args+=("--base-ref=${INPUT_BASE_REF}")
 if [[ -n "${INPUT_LINKS:-}" ]]; then
   while IFS= read -r link || [[ -n "$link" ]]; do


### PR DESCRIPTION
Exposes the `--include-subjects` CLI flag (added in linear/linear-release#76) as an `include_subjects` action input, following the same pattern as `include_paths`.
