### PR TITLE
Allow passing a GitHub token to authenticate CLI downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Once installed, run it from your AI agent with `/linear-release-setup` (or just 
 | `log_level`     | No       |          | Log verbosity: `quiet` or `verbose`. Omit for default output.                                                                                                                                                                 |
 | `timeout`       | No       | `60`     | Maximum time in seconds to wait for the command to complete                                                                                                                                                                   |
 | `cli_version`   | No       | `v0.14.0` | Linear Release CLI version to install                                                                                                                                                                                         |
+| `github_token`  | No       | `${{ github.token }}` | GitHub token used to authenticate the CLI download. Authenticating avoids the low anonymous rate limit that can fail on busy or shared runners. Defaults to the workflow's automatic token; pass your own token to use a higher rate limit. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: Linear Release CLI version to install (e.g., "v0.14.0"). Set to "latest" to always use the newest CLI.
     required: false
     default: v0.14.0
+  github_token:
+    description: GitHub token used to authenticate release downloads through the GitHub CLI. Defaults to the workflow's automatic token. Pass a personal access token or GitHub App token when downloading from another repository or when you need higher rate limits than the default token provides.
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   release-id:
@@ -81,6 +85,7 @@ runs:
       run: bash "${{ github.action_path }}/install.sh"
       env:
         CLI_VERSION: ${{ inputs.cli_version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Run Linear Release
       id: run

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,14 @@ else
 fi
 
 echo "Downloading Linear Release CLI from $URL"
-curl -fsSL "$URL" -o "$BIN_PATH"
+
+curl_args=(-fsSL)
+# Authenticate when a token is set for a higher rate limit; curl drops the header on the cross-host redirect to the asset CDN, so it's only sent to github.com.
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+curl "${curl_args[@]}" "$URL" -o "$BIN_PATH"
 chmod +x "$BIN_PATH"
 
 echo "Linear Release CLI installed at $BIN_PATH"


### PR DESCRIPTION
## What

Adds a github_token input so the Linear Release CLI download can be authenticated, avoiding the anonymous rate limit that can fail downloads on busy or shared runners. Defaults to the workflow’s automatic token, but a custom token can be passed if desired.

Closes #43 

🤖 Generated with [Claude Code](https://claude.com/claude-code)