### PR TITLE
Fix release PR body wording for drifted CLI version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,6 +123,8 @@ git checkout -b "$BRANCH"
 echo "Updating VERSION to $VERSION..."
 echo "$VERSION" > VERSION
 
+PREV_CLI_VERSION=$(grep -E '^    default: v[0-9]+\.[0-9]+\.[0-9]+$' action.yml | sed -E 's/.*default: v//')
+
 echo "Updating cli_version default in action.yml to v$CLI_VERSION..."
 sed -i.bak -E "s/^(    default: v)[0-9]+\.[0-9]+\.[0-9]+\$/\1$CLI_VERSION/" action.yml
 sed -i.bak -E "s/(Linear Release CLI version to install \(e\.g\., \"v)[0-9]+\.[0-9]+\.[0-9]+(\"\))/\1$CLI_VERSION\2/" action.yml
@@ -142,8 +144,10 @@ git push -u origin "$BRANCH"
 echo "Creating pull request..."
 if [ "$CLI_VERSION" = "$VERSION" ]; then
   PR_BODY="Bumps the action and default CLI version to v$VERSION."
-else
+elif [ "$CLI_VERSION" = "$PREV_CLI_VERSION" ]; then
   PR_BODY="Bumps the action to v$VERSION (default CLI version stays at v$CLI_VERSION)."
+else
+  PR_BODY="Bumps the action to v$VERSION (default CLI version bumped to v$CLI_VERSION)."
 fi
 PR_URL=$(gh pr create \
   --title "Release v$VERSION" \


### PR DESCRIPTION
The release script's PR body assumed that whenever the action version and default CLI version differ, the CLI version was unchanged — printing "default CLI version stays at vX". That's wrong when the CLI default drifts *and* moves in the same release (e.g. action `0.14.5`, CLI `0.14.2` → `0.14.3`): it read "stays at v0.14.3" even though v0.14.3 was new.

This captures the previous CLI default from `action.yml` before the bump and compares against it, so the body now distinguishes three cases:

- CLI tracks the action: `Bumps the action and default CLI version to vX.`
- CLI drifts but is unchanged from the last release: `... (default CLI version stays at vY).`
- CLI drifts and changed: `... (default CLI version bumped to vY).`