### PR TITLE
Expose the CLI --issue-pattern flag as an issue_pattern input

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once installed, run it from your AI agent with `/linear-release-setup` (or just 
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`)                                                                                                                                                    |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)                                                                                                                                                            |
 | `include_subjects` | No    |          | Filter commits whose subject (first line) matches a regular expression. Composes with `include_paths`.                                                                                                                        |
-| `issue_pattern` | No       |          | Extract issue identifiers from commit subjects using a custom regular expression with the identifier in capture group 1. Additive to the built-in detection.                                                                   |
+| `issue_pattern` | No       |          | Extract issue identifiers captured by group 1 of a regular expression from commit subjects. Additive to the built-in detection.                                                                                                |
 | `base_ref`      | No       |          | Override the `sync` scan base. Exclusive: scans `<base_ref>..HEAD`                                                                                                                                                            |
 | `links`         | No       |          | Links to attach to the targeted release, one per line. Each value must be either an absolute URL or `Label=URL`.                                                                                                              |
 | `documents`     | No       |          | Documents to attach to the targeted release, one per line as `[Title=]path/to/file.md` (title inferred from the filename if omitted). Existing documents with the same title are updated.                                       |
@@ -172,7 +172,7 @@ Use `include_subjects` to only scan commits whose subject (first line) matches a
 
 ### Custom issue patterns
 
-Use `issue_pattern` to extract issue identifiers from a custom commit-subject convention. Capture the identifier in group 1; the regex is applied to the subject only, case-insensitively, and anywhere in the subject, with all matches collected. It is additive to the built-in branch-name, magic-word, and subject-pattern detection.
+Use `issue_pattern` when commit subjects reference issues in a convention the built-in detection doesn't cover. The regex is matched case-insensitively anywhere in the subject (first line), with the identifier in capture group 1. Additive to the built-in branch-name, magic-word, and subject-pattern detection.
 
 ```yaml
 - uses: linear/linear-release-action@v0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Once installed, run it from your AI agent with `/linear-release-setup` (or just 
 | `stage`         | No       |          | Deployment stage such as `staging` or `production` (required for `update`)                                                                                                                                                    |
 | `include_paths` | No       |          | Filter commits by file paths (comma-separated globs for monorepos)                                                                                                                                                            |
 | `include_subjects` | No    |          | Filter commits whose subject (first line) matches a regular expression. Composes with `include_paths`.                                                                                                                        |
+| `issue_pattern` | No       |          | Extract issue identifiers from commit subjects using a custom regular expression with the identifier in capture group 1. Additive to the built-in detection.                                                                   |
 | `base_ref`      | No       |          | Override the `sync` scan base. Exclusive: scans `<base_ref>..HEAD`                                                                                                                                                            |
 | `links`         | No       |          | Links to attach to the targeted release, one per line. Each value must be either an absolute URL or `Label=URL`.                                                                                                              |
 | `documents`     | No       |          | Documents to attach to the targeted release, one per line as `[Title=]path/to/file.md` (title inferred from the filename if omitted). Existing documents with the same title are updated.                                       |
@@ -167,6 +168,17 @@ Use `include_subjects` to only scan commits whose subject (first line) matches a
   with:
     access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
     include_subjects: "[A-Z]{2,}-[0-9]+"
+```
+
+### Custom issue patterns
+
+Use `issue_pattern` to extract issue identifiers from a custom commit-subject convention. Capture the identifier in group 1; the regex is applied to the subject only, case-insensitively, and anywhere in the subject, with all matches collected. It is additive to the built-in branch-name, magic-word, and subject-pattern detection.
+
+```yaml
+- uses: linear/linear-release-action@v0
+  with:
+    access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+    issue_pattern: '\[([A-Z]+-\d+)\]'
 ```
 
 ### Scan base override

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: Filter commits whose subject (first line) matches a regular expression (e.g., "[A-Z]{2,}-[0-9]+"). Composes with include_paths.
     required: false
   issue_pattern:
-    description: 'Extract issue identifiers from commit subjects using a custom regular expression with the identifier in capture group 1 (e.g. "\[([A-Z]+-\d+)\]"). Additive to the built-in detection.'
+    description: 'Extract issue identifiers captured by group 1 of a regular expression from commit subjects (e.g., "\[([A-Z]+-\d+)\]"). Additive to the built-in detection.'
     required: false
   base_ref:
     description: "Override the sync scan base. Exclusive: scans <base_ref>..HEAD."

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   include_subjects:
     description: Filter commits whose subject (first line) matches a regular expression (e.g., "[A-Z]{2,}-[0-9]+"). Composes with include_paths.
     required: false
+  issue_pattern:
+    description: 'Extract issue identifiers from commit subjects using a custom regular expression with the identifier in capture group 1 (e.g. "\[([A-Z]+-\d+)\]"). Additive to the built-in detection.'
+    required: false
   base_ref:
     description: "Override the sync scan base. Exclusive: scans <base_ref>..HEAD."
     required: false
@@ -100,6 +103,7 @@ runs:
         INPUT_STAGE: ${{ inputs.stage }}
         INPUT_INCLUDE_PATHS: ${{ inputs.include_paths }}
         INPUT_INCLUDE_SUBJECTS: ${{ inputs.include_subjects }}
+        INPUT_ISSUE_PATTERN: ${{ inputs.issue_pattern }}
         INPUT_BASE_REF: ${{ inputs.base_ref }}
         INPUT_LINKS: ${{ inputs.links }}
         INPUT_DOCUMENTS: ${{ inputs.documents }}

--- a/run.sh
+++ b/run.sh
@@ -50,6 +50,7 @@ args=()
 [[ -n "${INPUT_STAGE:-}" ]] && args+=("--stage=${INPUT_STAGE}")
 [[ -n "${INPUT_INCLUDE_PATHS:-}" ]] && args+=("--include-paths=${INPUT_INCLUDE_PATHS}")
 [[ -n "${INPUT_INCLUDE_SUBJECTS:-}" ]] && args+=("--include-subjects=${INPUT_INCLUDE_SUBJECTS}")
+[[ -n "${INPUT_ISSUE_PATTERN:-}" ]] && args+=("--issue-pattern=${INPUT_ISSUE_PATTERN}")
 [[ -n "${INPUT_BASE_REF:-}" ]] && args+=("--base-ref=${INPUT_BASE_REF}")
 if [[ -n "${INPUT_LINKS:-}" ]]; then
   while IFS= read -r link || [[ -n "$link" ]]; do


### PR DESCRIPTION
The CLI gained `--issue-pattern` in v0.15.0 ([linear/linear-release#124](https://github.com/linear/linear-release/pull/124)) but the action never forwarded it. Adds an `issue_pattern` input mapped through `run.sh`, with README docs mirroring the CLI's.
