### PR TITLE
Authenticate the CI install test's GitHub API calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           CLI_VERSION: latest
           RUNNER_OS: ${{ runner.os }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   sync-release:
     name: Sync release management


### PR DESCRIPTION
Pass the workflow token to the `test-install` job. `install.sh` now resolves `latest` through the releases API (#60), and anonymous API calls from shared hosted-runner IPs 403 on rate limits. Consumers are unaffected — `action.yml` already passes `inputs.github_token` by default.
